### PR TITLE
Switch to binstubs for Rails and Rake commands

### DIFF
--- a/dip.yml
+++ b/dip.yml
@@ -22,7 +22,7 @@ interaction:
   rake:
     description: Run Rake commands
     service: app
-    command: bundle exec rake
+    command: bin/rake
 
   rspec:
     description: Run Rspec commands
@@ -34,7 +34,7 @@ interaction:
   rails:
     description: Run Rails commands
     service: app
-    command: bundle exec rails
+    command: bin/rails
     subcommands:
       s:
         description: Run Rails server at http://localhost:3000


### PR DESCRIPTION
Close #4.

Switching to binstubs as they are faster than `bundle exec`